### PR TITLE
Fix WarcraftClient#getCharacterClasses

### DIFF
--- a/lib/warcraft-client.js
+++ b/lib/warcraft-client.js
@@ -597,7 +597,7 @@ WarcraftClient.prototype.getCharacterClasses = function(cb) {
     throw new TypeError('"cb" must be a function');
   }
 
-  this._request('get', ['wow', 'data', 'battlegroups'], null, cb);
+  this._request('get', ['wow', 'data', 'character', 'classes'], null, cb);
 };
 
 /**


### PR DESCRIPTION
`WarcraftClient.prototype.getCharacterClasses` is sending a request to the wrong
endpoint (see [here](https://github.com/webmakersteve/battle-net.js/blob/d3f316c7afef6e3b7f3e911a5d6a3756f77b0ae5/lib/warcraft-client.js#L600)):

```
this._request('get', ['wow', 'data', 'battlegroups'], null, cb);
```

should be

```
this._request('get', ['wow', 'data', 'character', 'classes'], null, cb);
```
