### PR TITLE
Encode URI parameters

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -48,7 +48,7 @@ ApiClient.prototype.parseFields = function(fields) {
 */
 ApiClient.prototype._request = function (method, path, data, cb) {
   if (Array.isArray(path)) {
-    path = path.join('/');
+    path = path.map(encodeURIComponent).join('/');
   }
 
   if (data === undefined || data === null) {


### PR DESCRIPTION
Encode URI parameters using `encodeURIComponent`. Otherwise requests to paths containing special characters always fail.