### PR TITLE
Fix crash if response is missing a content type

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -77,7 +77,7 @@ ApiClient.prototype._request = function (method, path, data, cb) {
     var contentType = response.headers['content-type'];
 
     // We only care about the stuff before the semicolon, if there is one
-    if (contentType.indexOf(';')) {
+    if (contentType && contentType.indexOf(';')) {
       contentType = contentType.substring(0, contentType.indexOf(';'));
     }
 


### PR DESCRIPTION
For some invalid requests the Battle.net API returns responses without any content type set. This causes a crash in `ApiClient#_request`.