### PR TITLE
Expose request status code on error objects

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -2,6 +2,12 @@
 
 module.exports = ApiClient;
 
+function buildError(reason, response) {
+  var err = new Error(reason);
+  err.statusCode = response.statusCode;
+  return err;
+}
+
 function ApiClient(httpAdapter) {
   if (!(this instanceof ApiClient)) {
     return new ApiClient(httpAdapter);
@@ -90,16 +96,14 @@ ApiClient.prototype._request = function (method, path, data, cb) {
           // Error on our side
           if (returnObj.reason) {
             // Bad stuff
-            err = new Error(returnObj.reason);
-            cb(err);
+            cb(buildError(returnObj.reason, response));
           } else {
-           cb(new Error('Got a bad status code: ' + response.statusCode));
+            cb(buildError('Got a bad status code: ' + response.statusCode, response));
           }
         } else {
           if (returnObj.status && returnObj.status === 'nok') {
             // Bad stuff
-            err = new Error(returnObj.reason);
-            cb(err);
+            cb(buildError(returnObj.reason, response));
           } else {
             cb(null, returnObj);
           }
@@ -111,9 +115,9 @@ ApiClient.prototype._request = function (method, path, data, cb) {
       // Check status code first
       if (response.statusCode >= 300) {
         // Error on our side
-        return cb(new Error('Got a bad status code: ' + response.statusCode));
+        cb(buildError('Got a bad status code: ' + response.statusCode, response));
       } else {
-        cb(new Error(contentType + ': content type not supported.'));
+        cb(buildError(contentType + ': content type not supported.', response));
       }
     }
 


### PR DESCRIPTION
This PR adds the request's status code to most error objects returned by `ApiClient#_request`.