### PR TITLE
Add WarcraftClient#getUserCharacters

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ Gets a list of talents.
 
 Gets a list of pet types.
 
+### client.warcraft.getUserCharacters(token, cb)
+
+Gets a list of all characters of the user associated with the specified access token.
+
 # Other Stuff
 
 If you like my code, star it! If you use it, tell me about it! I'd love to hear how you can make use of this code in your application.

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -40,13 +40,19 @@ ApiClient.prototype.parseFields = function(fields) {
 * the necessary headers (eg auth, content type, user agent, etc).
 *
 * @param {string} method The HTTP method for the request
-* @param {string} url The full endpoint url (including query portion).
-* @param {Object} data (optional) The body of the request (will be converted to json).
-* @param {Object} header (optional) Any additional headers to go along with the request.
-* @return {Promise}
+* @param {string} path The full endpoint url (including query portion).
+* @param {Object} data (optional) The body of the request (will be converted to json)
+*                      or query parameters, depending on the specified request method.
+* @param {Object} opt (optional) Additional options.
+* @param {Object} opt.token (optional) The access token to use for the request.
+* @param {Function} cb The node-style callback to pass the result to.
 * @protected
 */
-ApiClient.prototype._request = function (method, path, data, cb) {
+ApiClient.prototype._request = function (method, path, data, opt, cb) {
+  if (typeof opt === 'function') {
+    cb = opt;
+    opt = null;
+  }
   if (Array.isArray(path)) {
     path = path.join('/');
   }
@@ -59,9 +65,11 @@ ApiClient.prototype._request = function (method, path, data, cb) {
 
   var options = {
     method: method,
-    url : path,
-    //auth: {user: this._token}, ONLY FOR OAUTH
+    url : path
   };
+  if (opt && opt.token) {
+    options.headers = {'Authorization': 'Bearer ' + opt.token};
+  }
 
   if (method === 'POST' || method === 'PUT') {
     options.body = data;

--- a/lib/warcraft-client.js
+++ b/lib/warcraft-client.js
@@ -725,3 +725,22 @@ WarcraftClient.prototype.getPetTypes = function(cb) {
 
   this._request('get', ['wow', 'data', 'pet', 'types'], null, cb);
 };
+
+WarcraftClient.prototype.getUserCharacters = function(token, cb) {
+  if (typeof token !== 'string') {
+    throw new TypeError('"token" must be a string');
+  }
+
+  if (cb === undefined) {
+    // If we don't have a CB check if fields is a CB
+    cb = function() {};
+  }
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('"cb" must be a function');
+  }
+
+  var opt = {token: token};
+  this._request('get', ['wow', 'user', 'characters'], null, opt, cb);
+};
+

--- a/tests/samples/wow/user-characters.json
+++ b/tests/samples/wow/user-characters.json
@@ -1,0 +1,122 @@
+{
+    "characters": [
+        {
+            "name": "Elaana",
+            "realm": "Antonidas",
+            "battlegroup": "Vengeance / Rache",
+            "class": 6,
+            "race": 11,
+            "gender": 1,
+            "level": 92,
+            "achievementPoints": 5815,
+            "thumbnail": "antonidas/255/85139711-avatar.jpg",
+            "spec": {
+                "name": "Blood",
+                "role": "TANK",
+                "backgroundImage": "bg-deathknight-blood",
+                "icon": "spell_deathknight_bloodpresence",
+                "description": "A dark guardian who manipulates and corrupts life energy to sustain herself in the face of an enemy onslaught.",
+                "order": 0
+            },
+            "lastModified": 1474476541000
+        },
+        {
+            "name": "Omgitsboss",
+            "realm": "Antonidas",
+            "battlegroup": "Vengeance / Rache",
+            "class": 12,
+            "race": 4,
+            "gender": 1,
+            "level": 110,
+            "achievementPoints": 7700,
+            "thumbnail": "antonidas/176/94885040-avatar.jpg",
+            "spec": {
+                "name": "Vengeance",
+                "role": "TANK",
+                "backgroundImage": "bg-warlock-demonology",
+                "icon": "ability_demonhunter_spectank",
+                "description": "Embraces the demon within to incinerate enemies and protect their allies.",
+                "order": 1
+            },
+            "guild": "Käsekuchenmafia",
+            "guildRealm": "Antonidas",
+            "lastModified": 1479687237000
+        },
+        {
+            "name": "Mtx",
+            "realm": "Azuremyst",
+            "battlegroup": "Glutsturm / Emberstorm",
+            "class": 8,
+            "race": 10,
+            "gender": 1,
+            "level": 100,
+            "achievementPoints": 8085,
+            "thumbnail": "azuremyst/72/63750728-avatar.jpg",
+            "spec": {
+                "name": "Fire",
+                "role": "DPS",
+                "backgroundImage": "bg-mage-fire",
+                "icon": "spell_fire_firebolt02",
+                "description": "Ignite enemies with balls of fire and combustive flames.",
+                "order": 1
+            },
+            "guild": "Hitmen for hire",
+            "guildRealm": "Azuremyst",
+            "lastModified": 1479010285000
+        },
+        {
+            "name": "Qntm",
+            "realm": "Antonidas",
+            "battlegroup": "Vengeance / Rache",
+            "class": 1,
+            "race": 22,
+            "gender": 0,
+            "level": 37,
+            "achievementPoints": 5710,
+            "thumbnail": "antonidas/63/85008191-avatar.jpg",
+            "spec": {
+                "name": "Fury",
+                "role": "DPS",
+                "backgroundImage": "bg-warrior-fury",
+                "icon": "ability_warrior_innerrage",
+                "description": "A furious berserker wielding a weapon in each hand, unleashing a flurry of attacks to carve her opponents to pieces.",
+                "order": 1
+            },
+            "lastModified": 1470861400000
+        },
+        {
+            "name": "Elonna",
+            "realm": "Antonidas",
+            "battlegroup": "Vengeance / Rache",
+            "class": 7,
+            "race": 11,
+            "gender": 1,
+            "level": 105,
+            "achievementPoints": 0,
+            "thumbnail": "antonidas/106/96469866-avatar.jpg",
+            "guild": "Käsekuchenmafia",
+            "guildRealm": "Antonidas",
+            "lastModified": 1479518512000
+        },
+        {
+            "name": "Artamir",
+            "realm": "Proudmoore",
+            "battlegroup": "Vengeance / Rache",
+            "class": 3,
+            "race": 1,
+            "gender": 0,
+            "level": 73,
+            "achievementPoints": 5515,
+            "thumbnail": "proudmoore/205/74627789-avatar.jpg",
+            "spec": {
+                "name": "Beast Mastery",
+                "role": "DPS",
+                "backgroundImage": "bg-hunter-beastmaster",
+                "icon": "ability_hunter_bestialdiscipline",
+                "description": "A master of the wild who can tame a wide variety of beasts to assist her in combat.",
+                "order": 0
+            },
+            "lastModified": 1424896660000
+        }
+    ]
+}

--- a/tests/warcraft-client.spec.js
+++ b/tests/warcraft-client.spec.js
@@ -33,6 +33,7 @@ var mock = {
   characterStats: require('./samples/wow/character-stats.json'),
   characterTalents: require('./samples/wow/character-talents.json'),
   characterTitles: require('./samples/wow/character-titles.json'),
+  userCharacters: require('./samples/wow/user-characters.json'),
   failure: require('./samples/wow/failure.json')
 };
 
@@ -301,6 +302,27 @@ describe('Warcraft client', function() {
       });
     });
 
+  });
+
+  describe('getUserCharacters', function() {
+    var client = new WarcraftClient(defaultRequest);
+
+    it('should fail if the first parameter is not a string', function() {
+      t.throws(function() {
+        client.getUserCharacters();
+      }, '"token" must be a string');
+    });
+
+    it('should properly fetch json', function(cb) {
+      scope
+        .get('/wow/user/characters?locale=en_US&apikey=mockkey')
+        .reply(200, JSON.stringify(mock.userCharacters));
+
+      client.getUserCharacters('mocktoken', function(err, response) {
+        t.ifError(err);
+        cb();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Changes/additions in this PR:
- Add `opt` argument to `ApiClient#_request` to pass additional arguments.
- If given, `opt.token` is used as access token for the request.
- Fix JSDoc comments for `ApiClient#_request`.
- `WarcraftClient#getUserCharacters` makes a call to the `/wow/user/characters` endpoint using the specified access token.